### PR TITLE
Update README.md to fix trailing whitespace command issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ as the tools to crete these pairs. The client and the  server will have to go th
 
 Create a keystore using java keytool. The command to do this is
 
-    keytool -genkey -alias ApiHubUATcertalias -keyalg RSA -keystore ApiHubUATkeystorejks  -keysize 2048
+    keytool -genkey -alias ApiHubUATcertalias -keyalg RSA -keystore ApiHubUATkeystorejks -keysize 2048
 
 Change the alias to reflect a name of choice, this will prompt you for a password , enter a password of choice
 


### PR DESCRIPTION
Fixed an issue with whitespace discovered by my teammate Afzan that caused us to waste a ton of time trying to figure out why the keystore wasn't found.

This will prevent future Experian customers from having issues when setting up the encryption keys for products like Experian AscendOps Prequal Of One (PQ1) and others.